### PR TITLE
implement O(1) map for game

### DIFF
--- a/src/gp_game.h
+++ b/src/gp_game.h
@@ -93,10 +93,17 @@ typedef struct {
 
 void print_agent(FILE *stream, const Agent *agent);
 
+// TODO: use Env type
+// TODO: Change env_map to struct
+// maybe other env types need to store additional data like agents
+#define ENV_MAP_NONE 0
+#define ENV_MAP_WALL 1
+#define ENV_MAP_FOOD 2
+#define ENV_MAP_AGENTS 3
+
 typedef struct {
     Agent agents[AGENTS_COUNT];
-    int foods[BOARD_HEIGHT][BOARD_WIDTH];
-    int walls[BOARD_HEIGHT][BOARD_WIDTH];
+    int env_map[BOARD_HEIGHT][BOARD_WIDTH];
 } Game;
 
 int random_int_range(int low, int high);
@@ -112,10 +119,13 @@ int is_cell_empty(const Game *game, Coord pos);
 Agent *agent_at(Game *game, Coord coord);
 
 Coord coord_infront_of_agent(const Agent *agent);
+/** deprecated */
 int *food_infront_of_agent(Game *game, size_t agent_index);
-// TODO: implement O(1) lookup for agents
+/** deprecated */
 Agent *agent_infront_of_agent(Game *game, size_t agent_index);
+/** deprecated */
 int *wall_infront_of_agent(Game *game, size_t agent_index);
+/** deprecated */
 Env env_infront_of_agent(Game *game, size_t agent_index);
 
 void init_game(Game *game);
@@ -125,7 +135,7 @@ void load_game(const char *filepath, Game *game);
 
 int is_everyone_dead(const Game *game);
 
-void step_agent(Agent *agent);
+void step_agent(Game *game, size_t agent_index);
 void execute_action(Game *game, size_t agent_index, Action action);
 void step_game(Game *game);
 

--- a/src/gp_logging.c
+++ b/src/gp_logging.c
@@ -57,7 +57,7 @@ void log_generation(FILE *stream, int gen, Game *game)
   int food_eaten = FOODS_COUNT;
   for (size_t y = 0; y < BOARD_HEIGHT; ++y) {
       for (size_t x = 0; x < BOARD_WIDTH; ++x) {
-          if (game->foods[y][x]) {
+          if (game->env_map[y][x] == ENV_MAP_FOOD) {
               food_eaten--;
           }
       }

--- a/src/gp_visual.c
+++ b/src/gp_visual.c
@@ -35,15 +35,11 @@ void render_agent(SDL_Renderer *renderer, Agent agent)
 
 void render_game(SDL_Renderer *renderer, const Game *game)
 {
-    for (size_t i = 0; i < AGENTS_COUNT; ++i) {
-        if (game->agents[i].health > 0) {
-            render_agent(renderer, game->agents[i]);
-        }
-    }
-
     for (int y = 0; y < BOARD_HEIGHT; ++y) {
         for (int x = 0; x < BOARD_WIDTH; ++x) {
-            if (game->foods[y][x]) {
+						int env = game->env_map[y][x];
+
+            if (env == ENV_MAP_FOOD) {
                 filledCircleRGBA(
                     renderer,
                     (int) floorf(x * CELL_WIDTH + CELL_WIDTH * 0.5f),
@@ -52,7 +48,7 @@ void render_game(SDL_Renderer *renderer, const Game *game)
                     HEX_COLOR(FOOD_COLOR));
             }
 
-            if (game->walls[y][x]) {
+            else if (env == ENV_MAP_WALL) {
                 SDL_Rect rect = {
                     (int) floorf(x * CELL_WIDTH),
                     (int) floorf(y * CELL_HEIGHT),
@@ -64,6 +60,13 @@ void render_game(SDL_Renderer *renderer, const Game *game)
 
                 SDL_RenderFillRect(renderer, &rect);
             }
+
+						else if(env >= ENV_MAP_AGENTS) {
+							int agent_index = env - ENV_MAP_AGENTS;
+							if (game->agents[agent_index].health > 0) {
+									render_agent(renderer, game->agents[agent_index]);
+							}
+						}
         }
     }
 }


### PR DESCRIPTION
Hi

Recently I watch YouTube series about this project, and have some idea to optimize it.

I saw how the game stores map data in separated arrays , which cause multiple source of truth issue. also it's not efficient to lookup agents in the map.

To rapid solve this issue , I introduce `env_map` which holds single source of truth about games map.
For now each tile is an integer , 0 means EMPTY , 1 means WALL , 2 means FOOD , and other keeps agents index (starting from 3).

by this approach each query about map (for any query type) is an array access and takes just O(1) .

Note: I didn't remove `Agent.pos` for now but they can easily be removed.